### PR TITLE
Apply VW brand guidelines: light theme, navy + Lake Blue palette

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,7 @@
         <wireui:scripts />
         @livewireStyles
     </head>
-    <body class="min-h-screen bg-zinc-900 text-zinc-100 flex flex-col">
+    <body class="min-h-screen bg-vw-off-white text-gray-900 flex flex-col antialiased">
         <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W2J52LNQ"
             height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
@@ -23,9 +23,9 @@
             {{ $slot }}
         </main>
 
-        <footer class="border-t border-zinc-800 py-6 mt-8">
+        <footer class="border-t border-vw-silver/40 bg-white py-6 mt-8">
             <div class="container mx-auto px-4 text-center">
-                <p class="text-xs tracking-widest uppercase text-zinc-600">
+                <p class="text-xs tracking-widest uppercase text-gray-400">
                     &copy; Joe Lee {{ date('Y') }}. All rights reserved.
                 </p>
             </div>

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -1,11 +1,11 @@
-<nav x-data="{ open: false }" class="fixed top-0 left-0 right-0 z-50 bg-zinc-950/95 backdrop-blur-sm border-b border-zinc-800/70">
+<nav x-data="{ open: false }" class="fixed top-0 left-0 right-0 z-50 bg-vw-navy shadow-md">
     <div class="container mx-auto px-4">
         <div class="flex items-center justify-between h-16">
 
             {{-- Brand --}}
             <a href="/" wire:navigate class="flex items-center gap-3 group">
-                <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-amber-500/10 ring-1 ring-amber-500/25 group-hover:ring-amber-400/50 transition-all duration-200">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <div class="flex items-center justify-center w-9 h-9 rounded-lg bg-white/10 ring-1 ring-white/20 group-hover:ring-white/40 transition-all duration-200">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-vw-blue" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M5 17H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h13l4 4v4a2 2 0 0 1-2 2h-1"/>
                         <circle cx="7" cy="17" r="2"/>
                         <circle cx="17" cy="17" r="2"/>
@@ -13,26 +13,26 @@
                     </svg>
                 </div>
                 <div class="leading-tight">
-                    <div class="text-sm font-bold text-white tracking-tight">Vintage <span class="text-amber-400">VW</span></div>
-                    <div class="text-xs text-zinc-500 tracking-widest uppercase">Decoder</div>
+                    <div class="text-sm font-bold text-white tracking-tight">Vintage <span class="text-vw-blue">VW</span></div>
+                    <div class="text-xs text-white/40 tracking-widest uppercase">Decoder</div>
                 </div>
             </a>
 
             {{-- Desktop Nav --}}
             <div class="hidden md:flex items-center gap-1">
                 <a href="/" wire:navigate
-                   class="px-3 py-1.5 rounded-md text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors duration-150">
+                   class="px-3 py-1.5 rounded-md text-sm font-medium text-white/70 hover:text-white hover:bg-white/10 transition-colors duration-150">
                     Decoder
                 </a>
                 <a href="/vins" wire:navigate
-                   class="px-3 py-1.5 rounded-md text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors duration-150">
+                   class="px-3 py-1.5 rounded-md text-sm font-medium text-white/70 hover:text-white hover:bg-white/10 transition-colors duration-150">
                     VIN List
                 </a>
             </div>
 
             {{-- Mobile hamburger --}}
             <button @click="open = !open"
-                    class="md:hidden flex items-center justify-center w-9 h-9 rounded-md text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors duration-150">
+                    class="md:hidden flex items-center justify-center w-9 h-9 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors duration-150">
                 <svg x-show="!open" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
                 </svg>
@@ -51,13 +51,13 @@
              x-transition:leave-start="opacity-100 translate-y-0"
              x-transition:leave-end="opacity-0 -translate-y-1"
              x-cloak
-             class="md:hidden border-t border-zinc-800/70 py-3 space-y-1">
+             class="md:hidden border-t border-white/10 py-3 space-y-1">
             <a href="/" wire:navigate @click="open = false"
-               class="block px-3 py-2 rounded-md text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors duration-150">
+               class="block px-3 py-2 rounded-md text-sm font-medium text-white/70 hover:text-white hover:bg-white/10 transition-colors duration-150">
                 Decoder
             </a>
             <a href="/vins" wire:navigate @click="open = false"
-               class="block px-3 py-2 rounded-md text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 transition-colors duration-150">
+               class="block px-3 py-2 rounded-md text-sm font-medium text-white/70 hover:text-white hover:bg-white/10 transition-colors duration-150">
                 VIN List
             </a>
         </div>

--- a/resources/views/livewire/results-array.blade.php
+++ b/resources/views/livewire/results-array.blade.php
@@ -1,16 +1,15 @@
 <div>
     @if (!empty($array))
-    <div class="flex flex-col items-center space-y-4 mt-4 p-4">
-        <h5 class="text-xl font-semibold float-right">{{ $title }}</h3>
-            <ul class="mt-5 space-y-2">
+        <div class="flex flex-col items-center py-3 border-b border-gray-100">
+            <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">{{ $title }}</h3>
+            <ul class="w-full space-y-1 text-sm">
                 @foreach ($array as $attribute => $value)
-                @if(empty($value))
-                    @continue
-                @endif
-                    <li class="w-full py-1 border-b-2 border-neutral-100 border-opacity-100 dark:border-opacity-50">
-                        {{ $value }}</li>
+                    @if (empty($value))
+                        @continue
+                    @endif
+                    <li class="py-1 border-b border-gray-100 text-gray-800">{{ $value }}</li>
                 @endforeach
             </ul>
-    </div>
+        </div>
     @endif
 </div>

--- a/resources/views/livewire/results-mcode.blade.php
+++ b/resources/views/livewire/results-mcode.blade.php
@@ -1,12 +1,15 @@
 <div>
-    <div class="flex flex-col items-center space-y-4 mt-4 p-4">
-        <h3 class="text-xl font-semibold">{{ $title }}</h3>
-        <ul class="mt-5 space-y-2">
-            @foreach ($array as $value)
-                <li
-                    class="w-full py-1 border-b-2 border-neutral-100 border-opacity-100 dark:border-opacity-50">
-                    {{ $value->code }} - {{ $value->description }}</li>
-            @endforeach
-        </ul>
-    </div>
+    @if (!empty($array) && count($array))
+        <div class="flex flex-col items-center py-3 border-b border-gray-100">
+            <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">{{ $title }}</h3>
+            <ul class="w-full space-y-1 text-sm">
+                @foreach ($array as $value)
+                    <li class="py-1 border-b border-gray-100 text-gray-800">
+                        <span class="text-vw-blue font-mono font-semibold">{{ $value->code }}</span>
+                        &mdash; {{ $value->description }}
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
 </div>

--- a/resources/views/livewire/results-string.blade.php
+++ b/resources/views/livewire/results-string.blade.php
@@ -1,11 +1,8 @@
 <div>
     @if (!empty($string))
-    <div class="flex flex-col items-center space-y-4 mt-4 p-4">
-            <h5 class="text-xl font-semibold float-right">{{ $title }}</h3>
-                <ul class="mt-5 space-y-2">
-                        <li class="w-full py-1 border-b-2 border-neutral-100 border-opacity-100 dark:border-opacity-50">
-                            {{ $string }}</li>
-                </ul>
+        <div class="flex flex-col items-center py-3 border-b border-gray-100">
+            <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">{{ $title }}</h3>
+            <p class="text-gray-800 text-sm">{{ $string }}</p>
         </div>
     @endif
 </div>

--- a/resources/views/livewire/vin-form.blade.php
+++ b/resources/views/livewire/vin-form.blade.php
@@ -1,15 +1,22 @@
 <div>
-    <section class="text-gray-600 body-font mb-10">
-        <section class="mt-16 text-cente">
-            <div class="mx-auto text-center text-white">
-                <h1 class="text-2xl/tight md:text-3xl/tight font-bold container  text-center lg:text-5xl/none">
-                    VW T2 (1970-1979) Vin Decoder
+    <section class="mb-10">
+        <section class="mt-10 text-center">
+            <div class="mx-auto">
+                <h1 class="text-2xl/tight md:text-3xl/tight font-bold container text-center lg:text-5xl/none text-vw-navy">
+                    VW T2 (1970–1979) Vin Decoder
                 </h1>
+                <p class="mt-2 text-sm text-gray-500 tracking-wide">Enter your M-plate data to decode your Volkswagen Type 2</p>
             </div>
         </section>
     </section>
+
     <div class="container mx-auto flex flex-wrap">
-        <div class="w-full md:w-2/5 lg:w-3/5" x-data="{ bgColor: $wire.busColor }" x-on:buscolour.window="bgColor = $event.detail.colour">
+
+        {{-- Bus illustration + colour selector --}}
+        <div class="w-full md:w-2/5 lg:w-3/5"
+             x-data="{ bgColor: $wire.busColor }"
+             x-on:buscolour.window="bgColor = $event.detail.colour">
+
             <div class="bus relative bus--full bus--top-white bus--bottom-love">
                 <div class="bus-body">
                     <div class="bus__body--top roof"></div>
@@ -19,9 +26,7 @@
                     <div class="bus__body--top gutter gutter--right"></div>
                     <div class="bus__body--top mid-top"></div>
                     <div class="bus__body--top bump"></div>
-
                     <div class="bus__body--bottom front" x-bind:style="'background: ' + bgColor"></div>
-
                     <div class="bus__body--bottomx front-middle"></div>
                     <div class="bus__body--bottomx front-middle--bottom"></div>
                     <div class="bus__body--bottomx grill">
@@ -61,14 +66,12 @@
                         <div class="wiper-arm"></div>
                         <div class="wiper-attachment"></div>
                     </div>
-
                     <div class="directional">
                         <div class="directional--off"></div>
                     </div>
                     <div class="directional directional--right">
                         <div class="directional--off"></div>
                     </div>
-
                     <div class="vw-logo vw-logo--shadow">
                         <span class="vw-logo__v"></span>
                         <span class="vw-logo__w">
@@ -83,7 +86,6 @@
                             <span class="vw-logo__w__leg-r"></span>
                         </span>
                     </div>
-
                     <div class="headlight">
                         <div class="headlight--off">
                             <div class="headlight--off__star"></div>
@@ -94,7 +96,6 @@
                             <div class="headlight--off__star"></div>
                         </div>
                     </div>
-
                     <div class="bumper">
                         <div class="bumper-top"></div>
                         <div class="bumper-straight bs-middle"></div>
@@ -126,206 +127,221 @@
                 </div>
             </div>
 
-            <div class="flex justify-center" x-data="{selectedColor: $wire.busColorSelector}" x-on:buscolour.window="selectedColor = $event.detail.colour">
-                    <select name="colorSelector" id="colorSelector" class="sm:w-3/6 md:w-2/6 m-1 px-4 py-2"
-                        x-model="selectedColor" @change="bgColor = $event.target.value">
-                        <option value="" selected disabled hidden>Select a Colour</option>
+            {{-- Colour selector --}}
+            <div class="flex justify-center"
+                 x-data="{ selectedColor: $wire.busColorSelector }"
+                 x-on:buscolour.window="selectedColor = $event.detail.colour">
+                <div class="relative sm:w-3/6 md:w-2/6 m-1">
+                    <select name="colorSelector" id="colorSelector"
+                            class="w-full appearance-none bg-white border border-vw-silver/60 rounded-lg px-4 py-2.5 text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-vw-blue/40 focus:border-vw-blue transition-colors duration-150 cursor-pointer shadow-sm"
+                            x-model="selectedColor"
+                            @change="bgColor = $event.target.value">
+                        <option value="" selected disabled hidden>Select a colour</option>
                         @foreach ($colors as $color)
                             <option value="{{ $color->hex_code }}"
-                                :selected="selectedColor === '{{ $color->hex_code }}'">
+                                    :selected="selectedColor === '{{ $color->hex_code }}'">
                                 {{ $color->name }}
                             </option>
                         @endforeach
                     </select>
-                </div>
-                <div class="flex justify-center mt-10">
-                    @if (!empty($vindetails->chassis_number))
-                        <span
-                            class="inline-flex items-center justify-center p-5 border-4 border-gray-500 bg-gray-300 rounded-lg mb-5">
-                            <span class="w-full">Vin URL:
-                                {{ route('vin', ['chassisNumber' => str_replace(' ', '', $vindetails->chassis_number)]) }}</span>
-                    @endif
-                    </span>
+                    <div class="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+                        <svg class="w-4 h-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/>
+                        </svg>
+                    </div>
                 </div>
             </div>
 
-            <div class="md:w-3/5 lg:w-2/5 lg:py-28 md:py-28 md:pl-6 sm:py-42">
-                <form wire:submit="save">
-                    <div class="flex justify-center">
-                        <div class="border-4 border-gray-500 bg-gray-300 rounded-lg p-2">
+            {{-- VIN permalink --}}
+            @if (!empty($vindetails->chassis_number))
+                <div class="flex justify-center mt-6">
+                    <div class="flex items-center gap-2 px-4 py-3 border border-vw-blue/30 bg-blue-50 rounded-xl text-sm max-w-full overflow-hidden">
+                        <svg class="w-4 h-4 text-vw-blue shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244"/>
+                        </svg>
+                        <span class="font-mono text-xs text-vw-navy truncate">
+                            {{ route('vin', ['chassisNumber' => str_replace(' ', '', $vindetails->chassis_number)]) }}
+                        </span>
+                    </div>
+                </div>
+            @endif
+        </div>
+
+        {{-- Form + Results --}}
+        <div class="md:w-3/5 lg:w-2/5 lg:py-28 md:py-28 md:pl-6 sm:py-42">
+            <form wire:submit="save">
+                <div class="flex justify-center">
+                    <div class="border border-vw-silver/40 bg-white rounded-xl p-5 w-full shadow-sm">
+                        <x-input
+                            wire:model.blur="form.chassis_number"
+                            label="Chassis Number"
+                            name="c"
+                            class="rounded-md !w-1/3 mb-1 vin-input"
+                            placeholder="CC CCC CCC"
+                        />
+                        <div class="mt-3">
                             <x-input
-                                wire:model.blur="form.chassis_number"
-                                label="Chassis Number"
-                                name="c"
-                                class="rounded-md !w-1/3 mb-1 vin-input"
-                                placeholder="CC CCC CCC"
+                                wire:model.blur="form.mcode_1"
+                                label="M-Plate"
+                                name="m"
+                                class="flex mb-1 vin-input"
+                                placeholder="MMM MMM MMM MMM MMM"
                             />
-                            <div>
+                        </div>
+                        <div class="flex gap-2 mt-3">
+                            <div class="flex-1">
                                 <x-input
-                                    wire:model.blur="form.mcode_1"
-                                    label="M-Plate"
-                                    name="m"
-                                    class="flex mb-1 vin-input"
-                                    placeholder="MMM MMM MMM MMM MMM"
+                                    wire:model.blur="form.paint_interior"
+                                    label="Paint / Interior"
+                                    name="p"
+                                    class="vin-input"
+                                    placeholder="PPPPII"
                                 />
                             </div>
-                            <div class="flex mb-1">
-                                <div class="mr-2">
-                                    <x-input
-                                        wire:model.blur="form.paint_interior"
-                                        label="M-Plate"
-                                        name="p"
-                                        class="w-2/5 vin-input"
-                                        placeholder="PPPPII"
-                                    />
-                                </div>
-                                <div>
-                                    <x-input
-                                        wire:model.blur="form.mcode_2"
-                                        label="M-Plate"
-                                        name="m2"
-                                        class="w-3/5 vin-input"
-                                        placeholder="MMM MMM MMM MMM"
-                                    />
-                                </div>
-                            </div>
-                            <div class="flex">
-                                <div class="mr-2">
-                                    <x-input
-                                        wire:model.blur="form.model_year"
-                                        label="Model Year"
-                                        name="d"
-                                        class="vin-input"
-                                        placeholder="DD"
-                                    />
-                                </div>
-                                <div class="mr-2">
-                                    <x-input
-                                        wire:model.blur="form.production_plan"
-                                        label="Production Plan"
-                                        name="u"
-                                        class="vin-input"
-                                        placeholder="UUUU"
-                                    />
-                                </div>
-                                <div class="mr-2">
-                                    <x-input
-                                        wire:model.blur="form.export_destination"
-                                        label="Export Dest"
-                                        name="e"
-                                        class="vin-input"
-                                        placeholder="EE"
-                                    />
-                                </div>
-                                <div>
-                                    <x-input
-                                        wire:model.blur="form.body_engine_model"
-                                        label="Engine Model"
-                                        name="x"
-                                        class="vin-input"
-                                        placeholder="TTTT"
-                                    />
-                                </div>
-                            </div>
-                            <div class="flex justify-center mt-1">
-                                    <x-errors />
+                            <div class="flex-1">
+                                <x-input
+                                    wire:model.blur="form.mcode_2"
+                                    label="M-Plate 2"
+                                    name="m2"
+                                    class="vin-input"
+                                    placeholder="MMM MMM MMM MMM"
+                                />
                             </div>
                         </div>
-                    </div>
-                    <div class="flex justify-center mt-2">
-                        <button
-                            class="bg-slate-900 hover:bg-slate-700 active:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50 text-white font-semibold h-12 px-6 rounded-lg w-full transition duration-150 ease-in-out shadow-lg focus:shadow-outline sm:w-auto md:text-base lg:w-1/2 xl:w-1/3 2xl:w-1/4 focus-visible:ring-sky-300 dark:bg-sky-500 dark:highlight-white/20 dark:hover:bg-sky-400 dark:active:bg-sky-600 disabled:opacity-50"
-                            type="submit">
-                            Decode Vin!
-                        </button>
-                    </div>
-                </form>
-                <div class="container mx-auto">
-                    @if (isset($results))
-                        <div class="border-4 border-gray-500 bg-gray-300 rounded-lg mt-5 p-4">
-                            @if (!empty($results->chassisNumber))
-                                <div class="flex flex-col items-center space-y-4">
-                                    <h3 class="text-xl font-semibold">Model Year</h3>
-                                    <ul class="mt-5 space-y-2">
-                                        <li
-                                            class="w-full border-b-2 border-neutral-100 border-opacity-100 dark:border-opacity-50">
-                                            Year - {{ $results->chassisNumber }}</li>
-                                    </ul>
-                                </div>
-                            @endif
-                            @if (isset($results->production))
-                                <livewire:results-string title="Production Date" :string="$results->production" />
-                            @endif
-
-                            @if ($results->mCode1->isNotEmpty())
-                                <livewire:results-mcode title="M-Codes" :array="$results->mCode1" />
-                            @endif
-
-
-                            @if ($results->mCode2->isNotEmpty())
-                                <livewire:results-mcode title="M-Codes" :array="$results->mCode2" />
-                            @endif
-
-                            @if ($results->paintCodes->isNotEmpty())
-                                <div class="flex flex-col items-center space-y-4 mt-4 p-4">
-                                    <h5 class="text-xl font-semibold">Paint Codes</h3>
-                                        <ul
-                                            class="mt-5 space-y-2 py-1 border-b-2 border-neutral-100 border-opacity-100 dark:border-opacity-50">
-                                            @foreach ($results->paintCodes as $paint_code)
-                                                <li> {{ $paint_code->plate_code }} - {{ $paint_code->color_code }}
-                                                </li>
-                                                <li>German - {{ $paint_code->german_name }}</li>
-                                                <li> English - {{ $paint_code->english_name }}</li>
-                                            @endforeach
-                                        </ul>
-                                </div>
-                            @endif
-
-                            @if ($results->interiorCodes->isNotEmpty())
-                                <div class="flex flex-col items-center space-y-4 mt-4 p-4">
-                                    <h5 class="text-xl font-semibold">Interior</h3>
-                                        <ul
-                                            class="mt-5 space-y-2 py-1 border-b-2 border-neutral-100 border-opacity-100 dark:border-opacity-50">
-                                            @foreach ($results->interiorCodes as $interior)
-                                                <li>
-                                                    {{ $interior->code }} - {{ $interior->material }}</li>
-                                                <li>
-                                                    German - {{ $interior->german_name }}</li>
-                                                <li>
-                                                    English - {{ $interior->english_name }}</li>
-                                            @endforeach
-                                        </ul>
-                                </div>
-                            @endif
-
-                            @if (isset($results->destination))
-                                <livewire:results-string title="Export Destination" :string="$results->destination" />
-                            @endif
-
-                            @if (isset($results->engineTrans))
-                                <livewire:results-array title="Model Details" :array="$results->engineTrans" />
-                            @endif
-                        </div>
-                    @else
-                        <section class="mt-5">
-                            <div class="flex justify-center border-4 border-gray-500 bg-gray-300 rounded-lg p-5">
-                                <p><span class="font-semibold">Volkswagen Type 2 M-Plate and VIN Decoder:</span>
-                                    Essential
-                                    Identification Tool for VW Buses from (1970-1979), Detailing Production Codes,
-                                    Equipment, Manufacturing Dates, Destination, Specifications, and Optional Extras</p>
+                        <div class="flex gap-2 mt-3">
+                            <div class="flex-1">
+                                <x-input
+                                    wire:model.blur="form.model_year"
+                                    label="Model Year"
+                                    name="d"
+                                    class="vin-input"
+                                    placeholder="DD"
+                                />
                             </div>
-                        </section>
-                    @endif
+                            <div class="flex-1">
+                                <x-input
+                                    wire:model.blur="form.production_plan"
+                                    label="Production Plant"
+                                    name="u"
+                                    class="vin-input"
+                                    placeholder="UUUU"
+                                />
+                            </div>
+                            <div class="flex-1">
+                                <x-input
+                                    wire:model.blur="form.export_destination"
+                                    label="Export Dest."
+                                    name="e"
+                                    class="vin-input"
+                                    placeholder="EE"
+                                />
+                            </div>
+                            <div class="flex-1">
+                                <x-input
+                                    wire:model.blur="form.body_engine_model"
+                                    label="Engine Model"
+                                    name="x"
+                                    class="vin-input"
+                                    placeholder="TTTT"
+                                />
+                            </div>
+                        </div>
+                        <div class="mt-3">
+                            <x-errors class="text-sm text-red-600" />
+                        </div>
+                    </div>
                 </div>
+
+                <div class="flex justify-center mt-3">
+                    <button type="submit"
+                            class="bg-vw-navy hover:bg-vw-navy-mid active:bg-vw-navy text-white font-semibold h-12 px-6 rounded-lg w-full transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-vw-blue focus:ring-offset-2 sm:w-auto lg:w-1/2 xl:w-1/3 2xl:w-1/4 disabled:opacity-50 shadow-sm">
+                        Decode VIN
+                    </button>
+                </div>
+            </form>
+
+            {{-- Results --}}
+            <div class="container mx-auto">
+                @if (isset($results))
+                    <div class="border border-vw-silver/40 bg-white rounded-xl mt-5 p-5 shadow-sm space-y-1">
+
+                        @if (!empty($results->chassisNumber))
+                            <div class="flex flex-col items-center py-3 border-b border-gray-100">
+                                <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-2">Model Year</h3>
+                                <p class="text-vw-navy font-medium">{{ $results->chassisNumber }}</p>
+                            </div>
+                        @endif
+
+                        @if (isset($results->production))
+                            <livewire:results-string title="Production Date" :string="$results->production" />
+                        @endif
+
+                        @if ($results->mCode1->isNotEmpty())
+                            <livewire:results-mcode title="M-Code Plate 1" :array="$results->mCode1" />
+                        @endif
+
+                        @if ($results->mCode2->isNotEmpty())
+                            <livewire:results-mcode title="M-Code Plate 2" :array="$results->mCode2" />
+                        @endif
+
+                        @if ($results->paintCodes->isNotEmpty())
+                            <div class="flex flex-col items-center py-3 border-b border-gray-100">
+                                <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">Paint Codes</h3>
+                                <ul class="w-full space-y-1 text-sm">
+                                    @foreach ($results->paintCodes as $paint_code)
+                                        <li class="py-1 border-b border-gray-100 text-gray-800">
+                                            <span class="text-vw-blue font-mono font-semibold">{{ $paint_code->plate_code }}</span>
+                                            &mdash; {{ $paint_code->color_code }}
+                                        </li>
+                                        <li class="py-0.5 text-gray-500 text-xs">DE: {{ $paint_code->german_name }}</li>
+                                        <li class="py-0.5 text-gray-500 text-xs">EN: {{ $paint_code->english_name }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        @if ($results->interiorCodes->isNotEmpty())
+                            <div class="flex flex-col items-center py-3 border-b border-gray-100">
+                                <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3">Interior</h3>
+                                <ul class="w-full space-y-1 text-sm">
+                                    @foreach ($results->interiorCodes as $interior)
+                                        <li class="py-1 border-b border-gray-100 text-gray-800">
+                                            <span class="text-vw-blue font-mono font-semibold">{{ $interior->code }}</span>
+                                            &mdash; {{ $interior->material }}
+                                        </li>
+                                        <li class="py-0.5 text-gray-500 text-xs">DE: {{ $interior->german_name }}</li>
+                                        <li class="py-0.5 text-gray-500 text-xs">EN: {{ $interior->english_name }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        @if (isset($results->destination))
+                            <livewire:results-string title="Export Destination" :string="$results->destination" />
+                        @endif
+
+                        @if (isset($results->engineTrans))
+                            <livewire:results-array title="Model Details" :array="$results->engineTrans" />
+                        @endif
+                    </div>
+                @else
+                    <section class="mt-5">
+                        <div class="border border-vw-silver/40 bg-white rounded-xl p-5 shadow-sm text-sm text-gray-500 leading-relaxed">
+                            <span class="font-semibold text-vw-navy">Volkswagen Type 2 M-Plate and VIN Decoder:</span>
+                            Essential identification tool for VW Buses from (1970–1979), detailing production codes,
+                            equipment, manufacturing dates, destination, specifications, and optional extras.
+                        </div>
+                    </section>
+                @endif
             </div>
         </div>
     </div>
+
     <script>
-
-document.addEventListener('livewire:init', () => {
-    window.addEventListener('buscolour', event => {
-        console.log(event);
-    });
-});
-
-</script>
+        document.addEventListener('livewire:init', () => {
+            window.addEventListener('buscolour', event => {
+                console.log(event);
+            });
+        });
+    </script>
+</div>

--- a/resources/views/livewire/vin-list.blade.php
+++ b/resources/views/livewire/vin-list.blade.php
@@ -1,42 +1,42 @@
 <div class="container mx-auto px-4 py-10">
 
     <div class="mb-6">
-        <h1 class="text-2xl font-bold text-white tracking-tight">VIN Registry</h1>
-        <p class="text-sm text-zinc-500 mt-1">Decoded VW T2 chassis records &mdash; 1970&ndash;1979</p>
+        <h1 class="text-2xl font-bold text-vw-navy tracking-tight">VIN Registry</h1>
+        <p class="text-sm text-gray-500 mt-1">Decoded VW T2 chassis records &mdash; 1970&ndash;1979</p>
     </div>
 
-    <div class="rounded-xl border border-zinc-800 overflow-hidden">
+    <div class="rounded-xl border border-vw-silver/40 overflow-hidden shadow-sm bg-white">
         <div class="overflow-x-auto">
             <table class="min-w-full text-sm text-left">
-                <thead class="bg-zinc-800/60 border-b border-zinc-700/80">
+                <thead class="bg-vw-navy text-white">
                     <tr>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap">Chassis No.</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden sm:table-cell">Prod. Date</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden md:table-cell">Model</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden md:table-cell">Paint</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden lg:table-cell">M-Code 1</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden lg:table-cell">M-Code 2</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden xl:table-cell">Plant</th>
-                        <th scope="col" class="px-4 py-3 font-semibold text-zinc-300 whitespace-nowrap hidden xl:table-cell">Export</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap">Chassis No.</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden sm:table-cell">Prod. Date</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden md:table-cell">Model</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden md:table-cell">Paint</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden lg:table-cell">M-Code 1</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden lg:table-cell">M-Code 2</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden xl:table-cell">Plant</th>
+                        <th scope="col" class="px-4 py-3 font-semibold whitespace-nowrap hidden xl:table-cell">Export</th>
                     </tr>
                 </thead>
-                <tbody class="divide-y divide-zinc-800/80">
+                <tbody class="divide-y divide-gray-100">
                     @foreach ($vins as $vin)
-                        <tr class="bg-zinc-900 hover:bg-zinc-800/50 transition-colors duration-100">
+                        <tr class="odd:bg-white even:bg-gray-50 hover:bg-blue-50 transition-colors duration-100">
                             <td class="px-4 py-3 whitespace-nowrap">
                                 <a href="/vin/{{ Str::replace(' ', '', $vin->chassis_number) }}"
                                    wire:navigate.hover
-                                   class="font-mono font-semibold text-amber-400 hover:text-amber-300 transition-colors duration-150">
+                                   class="font-mono font-semibold text-vw-navy hover:text-vw-blue transition-colors duration-150">
                                     {{ $vin->chassis_number }}
                                 </a>
                             </td>
-                            <td class="px-4 py-3 text-zinc-400 whitespace-nowrap hidden sm:table-cell">{{ $vin->model_year }}</td>
-                            <td class="px-4 py-3 text-zinc-300 whitespace-nowrap hidden md:table-cell">{{ $vin->body_engine_model }}</td>
-                            <td class="px-4 py-3 text-zinc-400 whitespace-nowrap hidden md:table-cell">{{ $vin->paint_interior }}</td>
-                            <td class="px-4 py-3 text-zinc-500 font-mono text-xs whitespace-nowrap hidden lg:table-cell">{{ $vin->mcode_1 }}</td>
-                            <td class="px-4 py-3 text-zinc-500 font-mono text-xs whitespace-nowrap hidden lg:table-cell">{{ $vin->mcode_2 }}</td>
-                            <td class="px-4 py-3 text-zinc-500 whitespace-nowrap hidden xl:table-cell">{{ $vin->production_plan }}</td>
-                            <td class="px-4 py-3 text-zinc-500 whitespace-nowrap hidden xl:table-cell">{{ $vin->export_destination }}</td>
+                            <td class="px-4 py-3 text-gray-600 whitespace-nowrap hidden sm:table-cell">{{ $vin->model_year }}</td>
+                            <td class="px-4 py-3 text-gray-800 whitespace-nowrap hidden md:table-cell">{{ $vin->body_engine_model }}</td>
+                            <td class="px-4 py-3 text-gray-600 whitespace-nowrap hidden md:table-cell">{{ $vin->paint_interior }}</td>
+                            <td class="px-4 py-3 text-gray-500 font-mono text-xs whitespace-nowrap hidden lg:table-cell">{{ $vin->mcode_1 }}</td>
+                            <td class="px-4 py-3 text-gray-500 font-mono text-xs whitespace-nowrap hidden lg:table-cell">{{ $vin->mcode_2 }}</td>
+                            <td class="px-4 py-3 text-gray-500 whitespace-nowrap hidden xl:table-cell">{{ $vin->production_plan }}</td>
+                            <td class="px-4 py-3 text-gray-500 whitespace-nowrap hidden xl:table-cell">{{ $vin->export_destination }}</td>
                         </tr>
                     @endforeach
                 </tbody>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,16 @@ export default {
     extend: {
         fontFamily: {
             'Roboto': ['"Roboto"', 'cursive'],
-          },
+        },
+        colors: {
+            vw: {
+                navy:       '#001E50',
+                'navy-mid': '#1F2F57',
+                blue:       '#6091C3',
+                silver:     '#C2C3C4',
+                'off-white': '#FDFAF9',
+            },
+        },
     },
   },
   plugins: [


### PR DESCRIPTION
## Brand research summary

VW's 2019 rebrand (led by MetaDesign with HvD Fonts) established a "digital-first, no filter" identity built on two primary colours and a white canvas. No decorative gradients or heavy shadows — products and typography breathe.

| Token | Hex | Role |
|---|---|---|
| VW Dark Blue | `#001E50` | Nav, headings, primary CTA, table header |
| Lake Blue | `#6091C3` | Accent, interactive states, code highlights |
| Silver | `#C2C3C4` | Borders, dividers |
| Off-White | `#FDFAF9` | Page background (VW "Matte White") |

---

## What changed

### `tailwind.config.js`
New colour tokens: `vw-navy`, `vw-navy-mid`, `vw-blue`, `vw-silver`, `vw-off-white` — used throughout in place of arbitrary values.

### Layout (`app.blade.php`)
- **Removed `class="dark"`** — the app is now light-first in line with VW's white-canvas principle
- Body: `bg-vw-off-white` (#FDFAF9 warm off-white), `text-gray-900`
- Footer: white background, silver border

### Nav (`nav.blade.php`)
- Background: `bg-vw-navy` (#001E50) — matches vw.com's navigation exactly
- Brand icon and "VW" wordmark highlight in Lake Blue (`text-vw-blue`)
- Nav links: `text-white/70` → `text-white` + `bg-white/10` pill on hover

### VIN List (`vin-list.blade.php`)
- Table header `bg-vw-navy` with white text
- White card with `border-vw-silver/40` and `shadow-sm`
- Chassis number links: navy → Lake Blue on hover
- Row hover: `bg-blue-50` (on-brand light blue tint)

### Form + Results (`vin-form.blade.php`)
- Page heading `text-vw-navy`
- Form card: white background, silver border, `shadow-sm`
- Colour selector: white with silver border, Lake Blue focus ring
- VIN permalink: `bg-blue-50` pill with `border-vw-blue/30`
- Submit button: `bg-vw-navy` → `hover:bg-vw-navy-mid` (replaces amber)
- Results card: white with silver border
- Section headings: `xs uppercase tracking-widest text-gray-400`
- Code values: `text-vw-blue font-mono font-semibold`

### Result sub-components (`results-string`, `results-mcode`, `results-array`)
- Unified heading style matching form results
- Body text `text-gray-800`, dividers `border-gray-100`
- M-codes and paint codes in Lake Blue monospace

## Test plan
- [ ] Light background renders correctly (no dark mode bleedthrough)
- [ ] Nav displays in VW Dark Blue with white text
- [ ] Form inputs and labels are clearly legible on the white card
- [ ] Colour selector works and updates the bus illustration
- [ ] Decode button triggers submission
- [ ] Results panel sections render with correct colours
- [ ] VIN list table header is navy, rows stripe correctly on hover

https://claude.ai/code/session_01KBGgMKRdnxa67ULJEmZ5LM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBGgMKRdnxa67ULJEmZ5LM)_